### PR TITLE
Apply bash best practices and add CRUSH guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 temp_store/
+.crush/

--- a/CRUSH.md
+++ b/CRUSH.md
@@ -1,0 +1,29 @@
+CRUSH.md — Quickstart for agents working in this repo
+
+Build / Run / Test
+- This repo is a small shell-based helper to run a local multi-node CockroachDB cluster via tmux. There is no language toolchain or test framework here.
+- Primary entrypoint: ./tmux_cluster.sh
+- Run with defaults: ./tmux_cluster.sh
+- Override ports/window/store: TMUX_WINDOW=crdb-cluster BASE_SQL_PORT=26257 BASE_HTTP_PORT=8080 STORE_DIRECTORY=temp_store ./tmux_cluster.sh
+- Example alt cluster: TMUX_WINDOW=crdb-cluster-two BASE_SQL_PORT=26357 BASE_HTTP_PORT=8090 STORE_DIRECTORY=temp_store_2 ./tmux_cluster.sh
+- Start detached (tmux server persists panes): tmux new-session -d -s crdb && TMUX_WINDOW=crdb BASE_SQL_PORT=26257 BASE_HTTP_PORT=8080 STORE_DIRECTORY=temp_store ./tmux_cluster.sh
+- Stop/cleanup: kill tmux session (tmux kill-session -t crdb) and remove store dirs (rm -rf temp_store temp_store_2)
+- Lint/format: Shell script only. Use shellcheck and shfmt if available:
+  - shellcheck tmux_cluster.sh
+  - shfmt -w tmux_cluster.sh
+- Tests: No automated tests exist. To validate, run the script and ensure Cockroach nodes start and UIs are reachable on specified ports. To “run a single test,” run a targeted shellcheck rule: shellcheck -s bash -o all -e SC1090 tmux_cluster.sh (adjust -e to focus rules).
+
+Code Style Guidelines (Shell)
+- Shell: Bash-compatible. Keep POSIX where practical; rely on common tmux and cockroach CLI.
+- Imports/execs: Prefer absolute or repo-relative paths; check tools exist before use (command -v cockroach >/dev/null 2>&1).
+- Formatting: Use shfmt defaults; 2-space indent; align continued lines; keep lines under ~100 chars.
+- Variables: UPPER_SNAKE for env/config (TMUX_WINDOW, BASE_SQL_PORT); local variables lower_snake; quote all expansions ("$var").
+- Defaults: Provide safe defaults via : or ${VAR:-default}. Validate numeric ports and directories before use.
+- Functions: small, single-purpose; name as verb_noun; return nonzero on error.
+- Error handling: set -euo pipefail where safe; check commands (if ! tmux new-window ...; then ... fi); propagate exit codes.
+- Traps/cleanup: use trap 'cleanup' EXIT to close panes or temporary dirs when appropriate.
+- Naming: Scripts and files in lower_snake; temporary data under temp_store*/.
+- Logging: echo prefixed levels (INFO:, WARN:, ERROR:) to stderr for errors (>&2).
+
+Cursor/Copilot Rules
+- No Cursor or Copilot rules found in this repo at the time of writing. If added later (e.g., .cursor/rules/, .cursorrules, or .github/copilot-instructions.md), mirror key conventions here.

--- a/tmux_cluster.sh
+++ b/tmux_cluster.sh
@@ -2,70 +2,92 @@
 # tmux_cluster.sh
 # Usage: ./tmux_cluster.sh [NUM_NODES]
 
-set -exuo pipefail
+set -euo pipefail
 
-NODES="${1:-3}"                 # default: 3 nodes
+if [[ "${DEBUG:-}" == "1" ]]; then
+  set -x
+fi
+
+command -v tmux >/dev/null 2>&1 || { echo "ERROR: tmux not found" >&2; exit 1; }
+command -v cockroach >/dev/null 2>&1 || { echo "ERROR: cockroach not found" >&2; exit 1; }
+
+NODES="${1:-3}"
 BASE_SQL_PORT="${BASE_SQL_PORT:-26257}"
 BASE_HTTP_PORT="${BASE_HTTP_PORT:-8080}"
 STORE_DIRECTORY="${STORE_DIRECTORY:-temp_store}"
 TMUX_WINDOW="${TMUX_WINDOW:-crdb-cluster}"
 
-# define a comma-separated list of regions (no spaces!) and split into an array
 REGIONS_CSV="${REGIONS_CSV:-us-east,us-west,us-central}"
-IFS=',' read -r -a REGIONS <<< "$REGIONS_CSV"
+OLD_IFS=$IFS; IFS=',' read -r -a REGIONS <<< "$REGIONS_CSV"; IFS=$OLD_IFS
 
-# Ensure we're inside a tmux session
 if [[ -z "${TMUX:-}" ]]; then
-  echo "This script must be run inside an existing tmux session."
+  echo "ERROR: This script must be run inside an existing tmux session." >&2
   exit 1
 fi
 
-# Build the --join list
+case "$NODES" in
+  ''|*[!0-9]*) echo "ERROR: NODES must be a positive integer" >&2; exit 1;;
+  *) if (( NODES < 1 )); then echo "ERROR: NODES must be >= 1" >&2; exit 1; fi;;
+esac
+
+for p in "$BASE_SQL_PORT" "$BASE_HTTP_PORT"; do
+  case "$p" in ''|*[!0-9]*) echo "ERROR: Ports must be integers" >&2; exit 1;; esac
+  if (( p < 1 || p > 65535 )); then echo "ERROR: Port $p out of range" >&2; exit 1; fi
+done
+
+mkdir -p "$STORE_DIRECTORY"
+
 join=""
 for i in $(seq 0 $((NODES-1))); do
   join+="localhost:$((BASE_SQL_PORT+i)),"
+  mkdir -p "$STORE_DIRECTORY/node$((i+1))"
 done
-join=${join%,}  # remove trailing comma
-  
-region="${REGIONS[0]}"
-# Make the first pane the base (node 1)
-tmux new-window -n $TMUX_WINDOW cockroach start \
-  --insecure \
-  --store=$STORE_DIRECTORY/node1 \
-  --listen-addr=localhost:$BASE_SQL_PORT \
-  --http-addr=localhost:$BASE_HTTP_PORT \
-  --locality=region=$region \
-  --join=$join
+join=${join%,}
 
-# Add remaining nodes below
+region="${REGIONS[0]}"
+
+if ! tmux new-window -n "$TMUX_WINDOW" cockroach start \
+  --insecure \
+  --store="$STORE_DIRECTORY/node1" \
+  --listen-addr="localhost:$BASE_SQL_PORT" \
+  --http-addr="localhost:$BASE_HTTP_PORT" \
+  --locality="region=$region" \
+  --join="$join"; then
+  echo "ERROR: failed to start node1" >&2; exit 1
+fi
+
 for i in $(seq 2 "$NODES"); do
   sql_port=$((BASE_SQL_PORT + i - 1))
   http_port=$((BASE_HTTP_PORT + i - 1))
   store="node$i"
-
-  # pick region by rotating through the array
   idx=$(( (i-1) % ${#REGIONS[@]} ))
   region="${REGIONS[$idx]}"
 
-  tmux split-window -v cockroach start \
+  if ! tmux split-window -v cockroach start \
     --insecure \
-    --store=$STORE_DIRECTORY/$store \
-    --listen-addr=localhost:$sql_port \
-    --http-addr=localhost:$http_port \
-    --locality=region=$region \
-    --join=$join
+    --store="$STORE_DIRECTORY/$store" \
+    --listen-addr="localhost:$sql_port" \
+    --http-addr="localhost:$http_port" \
+    --locality="region=$region" \
+    --join="$join"; then
+    echo "ERROR: failed to start $store" >&2; exit 1
+  fi
   tmux select-layout -t "$TMUX_WINDOW" even-vertical
+  echo "INFO: Started $store (sql:$sql_port http:$http_port region:$region)"
 done
 
 tmux select-layout -t "$TMUX_WINDOW" even-vertical
-tmux split-window -hf -p 80 "sleep 3 && cockroach init --insecure --host=localhost:$BASE_SQL_PORT && \
-   cockroach sql --insecure --host=localhost:$BASE_SQL_PORT"
+
+tmux split-window -hf -p 80 "sleep 3 && cockroach init --insecure --host=localhost:$BASE_SQL_PORT && cockroach sql --insecure --host=localhost:$BASE_SQL_PORT"
+
 tmux split-window -v -p 75
 
 sleep 5
 
-if command -v open &>/dev/null; then
-  open "http://localhost:$BASE_HTTP_PORT"
-elif command -v xdg-open &>/dev/null; then
-  xdg-open "http://localhost:$BASE_HTTP_PORT"
+if [[ "${OPEN_UI:-1}" == "1" ]]; then
+  if command -v open &>/dev/null; then
+    open "http://localhost:$BASE_HTTP_PORT"
+  elif command -v xdg-open &>/dev/null; then
+    xdg-open "http://localhost:$BASE_HTTP_PORT"
+  fi
 fi


### PR DESCRIPTION
## Summary
- Apply bash best practices to tmux_cluster.sh: tool checks, input validation, safe quoting, mkdir -p, optional DEBUG/OPEN_UI, clearer logging and error handling
- Add concise CRUSH.md for agents with run/lint guidance and shell style conventions
- Ignore .crush directory in .gitignore

## Test plan
- Syntax check: bash -n tmux_cluster.sh (passes)
- Optional static analysis: shellcheck tmux_cluster.sh
- Manual run: start within tmux, verify nodes start and UI opens on BASE_HTTP_PORT; toggle OPEN_UI=0 and DEBUG=1 to verify behavior

Generated by AI (GPT-5) and Crush.

💘 Generated with Crush
